### PR TITLE
Add experience banner and dropdown services

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -429,6 +429,60 @@ a {
   margin-top: 1rem;
 }
 
+/* EXPERIENCE BANNER */
+.experience-banner {
+  background: #f2f2f2;
+  padding: var(--spacing-lg) 0;
+  text-align: center;
+}
+.experience-banner h3 {
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+/* SERVICE LIST */
+.service-list {
+  max-width: 600px;
+  margin: auto;
+  text-align: left;
+}
+.service-category {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+.category-title {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  position: relative;
+}
+.category-title::after {
+  content: '+';
+  position: absolute;
+  right: 1rem;
+  transition: transform 0.2s;
+}
+.category-title.open::after {
+  content: '-';
+}
+.sub-services {
+  list-style: none;
+  padding: 0 1rem 1rem 1.5rem;
+  display: none;
+}
+.sub-services.open {
+  display: block;
+}
+.sub-services li {
+  margin: 0.4rem 0;
+}
+.sub-services a {
+  color: var(--primary-color);
+}
+
 /* FOOTER */
 .footer {
   background: var(--dark-color);
@@ -454,5 +508,8 @@ a {
   }
   .contact-grid {
     grid-template-columns: 1fr;
+  }
+  .experience-banner h3 {
+    font-size: 1.4rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -55,6 +55,13 @@
     </div>
   </section>
 
+  <!-- Experience Banner -->
+  <section class="experience-banner">
+    <div class="container">
+      <h3>10+ Years of Experience in Interior Decoration</h3>
+    </div>
+  </section>
+
   <!-- Carousel Section -->
   <section class="carousel-section">
     <div class="container">
@@ -72,7 +79,7 @@
   <section class="categories">
     <div class="container">
       <h2 class="section-title">Service Categories</h2>
-      <div class="category-grid" id="category-grid"></div>
+      <div class="service-list" id="service-list"></div>
     </div>
   </section>
 

--- a/js/data.js
+++ b/js/data.js
@@ -6,10 +6,42 @@ const projectImages = [
   { src: "assets/a5.jpg", alt: "Aluminium window fitting" }
 ];
 
-const serviceCategories = [
-  { name: "False Ceiling", link: "services.html#false-ceiling" },
-  { name: "Aluminum Partition", link: "services.html#flooring" },
-  { name: "Roller Screens", link: "services.html#roller-screens" },
-  { name: "Aluminium Partitions", link: "services.html#partitions" },
-  { name: "Aluminium Windows", link: "services.html#windows" }
+const serviceList = [
+  {
+    name: "False Ceiling",
+    services: [
+      { name: "POP Design", id: "pop" },
+      { name: "Gypsum Board", id: "gypsum" },
+      { name: "Grid Ceiling", id: "grid" }
+    ]
+  },
+  {
+    name: "Flooring",
+    services: [
+      { name: "Vinyl Flooring", id: "vinyl" },
+      { name: "Wooden Flooring", id: "wooden" },
+      { name: "Carpet Tiles", id: "carpet" }
+    ]
+  },
+  {
+    name: "Roller Screens",
+    services: [
+      { name: "Blackout Roller", id: "blackout" },
+      { name: "Sunscreen Roller", id: "sunscreen" }
+    ]
+  },
+  {
+    name: "Aluminium Partitions",
+    services: [
+      { name: "Office Partition", id: "officepart" },
+      { name: "Glass Partition", id: "glasspart" }
+    ]
+  },
+  {
+    name: "Aluminium Windows",
+    services: [
+      { name: "Sliding Windows", id: "sliding" },
+      { name: "Casement Windows", id: "casement" }
+    ]
+  }
 ];

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   const carouselWrapper = document.getElementById("carousel-wrapper");
-  const categoryGrid = document.getElementById("category-grid");
+  const serviceListEl = document.getElementById("service-list");
 
   if (carouselWrapper) {
     projectImages.forEach(project => {
@@ -31,13 +31,32 @@ document.addEventListener("DOMContentLoaded", () => {
 
   }
 
-  if (categoryGrid) {
-    serviceCategories.forEach(category => {
-      const card = document.createElement("a");
-      card.href = category.link;
-      card.className = "category-card";
-      card.textContent = category.name;
-      categoryGrid.appendChild(card);
+  if (serviceListEl) {
+    serviceList.forEach(cat => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "service-category";
+
+      const title = document.createElement("div");
+      title.className = "category-title";
+      title.textContent = cat.name;
+
+      const list = document.createElement("ul");
+      list.className = "sub-services";
+
+      cat.services.forEach(item => {
+        const li = document.createElement("li");
+        li.innerHTML = `<a href="products.html#${item.id}">${item.name}</a>`;
+        list.appendChild(li);
+      });
+
+      title.addEventListener("click", () => {
+        list.classList.toggle("open");
+        title.classList.toggle("open");
+      });
+
+      wrapper.appendChild(title);
+      wrapper.appendChild(list);
+      serviceListEl.appendChild(wrapper);
     });
   }
 });

--- a/products.html
+++ b/products.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Products - AV Interior</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+<header class="navbar">
+  <div class="container nav-container">
+    <h1 class="logo">AV INTERIOR DECORATION</h1>
+    <nav class="nav-links desktop-nav">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="projects.html">Projects</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <div class="menu-icon" onclick="toggleMenu()">☰</div>
+    <div class="mobile-nav-card" id="mobileNav">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="projects.html">Projects</a>
+      <a href="contact.html">Contact</a>
+    </div>
+  </div>
+</header>
+
+<section class="services-page">
+  <div class="container">
+    <h2 class="section-title">Product Placeholder</h2>
+    <p>This page will showcase our products soon.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="container">
+    <p>&copy; 2025 AV Interior Decoration. All rights reserved.</p>
+  </div>
+</footer>
+<script>
+function toggleMenu() {
+  document.getElementById('mobileNav').classList.toggle('active');
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- highlight 10+ years of experience after the hero
- add collapsible service list linking to placeholder products.html
- style new sections for clarity and mobile
- update data and JS logic for dropdown categories
- include a placeholder `products.html` page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68417b3454cc8321b7da2908615c09e4