### PR TITLE
Enable continuous carousel animation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -302,11 +302,11 @@ a {
   gap: 1.5rem;
   padding: var(--spacing-lg) var(--spacing-md);
   width: max-content;
-  scroll-snap-type: x mandatory;
+  scroll-snap-type: none;
 }
 .carousel-item {
   flex: 0 0 auto;
-  scroll-snap-align: center;
+  scroll-snap-align: none;
 }
 .carousel-item img {
   width: 280px;


### PR DESCRIPTION
## Summary
- duplicate carousel slides for an infinite loop
- continuously scroll carousel using `requestAnimationFrame`
- disable snap behavior for smoother motion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851568122b483218a969319db8c4ec4