### PR TITLE
Add liquid glass effect to hero slide

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -164,6 +164,18 @@ a {
   }
 }
 
+@keyframes glassMorph {
+  0% {
+    border-radius: 60% 40% 30% 70% / 60% 40% 70% 30%;
+  }
+  50% {
+    border-radius: 40% 60% 70% 30% / 30% 70% 40% 60%;
+  }
+  100% {
+    border-radius: 60% 40% 30% 70% / 60% 40% 70% 30%;
+  }
+}
+
 @media (max-width: 768px) {
   .menu-icon {
     display: block;
@@ -235,6 +247,19 @@ a {
   display: none;
   width: 100%;
   overflow: hidden;
+  position: relative;
+}
+
+.hero-carousel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(12px);
+  border-radius: 60% 40% 30% 70% / 60% 40% 70% 30%;
+  pointer-events: none;
+  animation: glassMorph 8s ease-in-out infinite;
+  z-index: 1;
 }
 .hero-blob {
   display: none;


### PR DESCRIPTION
## Summary
- create `glassMorph` keyframes for morphing blur overlay
- apply animated glass overlay on `.hero-carousel`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68527ccc94a08321a3bc986c430d134c