### PR TITLE
Organize service page into grouped sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -433,6 +433,15 @@ a {
 .services-page {
   padding: var(--spacing-lg) 0;
 }
+.service-group {
+  margin-bottom: var(--spacing-lg);
+}
+.service-group-title {
+  font-family: "DM Serif Text", serif;
+  font-size: 1.75rem;
+  margin-bottom: var(--spacing-md);
+  color: var(--text-color);
+}
 .services-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -620,19 +629,44 @@ a {
 }
 .sub-services {
   list-style: none;
-  padding: 0 1rem 1rem 1.5rem;
-  display: none;
+  padding: 0 1rem;
+  margin-top: 0;
+  max-height: 0;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  transition: max-height 0.3s ease;
 }
 .sub-services.open {
-  display: block;
+  padding-bottom: 1rem;
+  max-height: 500px;
 }
 .sub-services li {
-  margin: 0.4rem 0;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  padding: 0.5rem;
+  text-align: center;
 }
 .sub-services a {
   display: block;
-  padding: 0.25rem 0;
   color: var(--primary-color);
+  font-weight: 500;
+  text-decoration: none;
+}
+.sub-card img {
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 0.25rem;
+}
+.sub-card span {
+  display: block;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
 }
 
 

--- a/js/data.js
+++ b/js/data.js
@@ -18,44 +18,48 @@ const serviceList = [
   {
     name: "False Ceiling",
     services: [
-      { name: "Gypsum Ceiling", id: "gypsum" },
-      { name: "Grid Ceiling", id: "grid" },
-      { name: "PVC ceiling", id: "pvcc" },
-      { name: "Wooden Ceiling", id: "woodc" }
+      { name: "Gypsum Ceiling", id: "gypsum", img: "assets/a6.jpg" },
+      { name: "Grid Ceiling", id: "grid", img: "assets/a3.jpg" },
+      { name: "PVC Ceiling", id: "pvc", img: "assets/a2.jpg" },
+      { name: "Wooden Ceiling", id: "woodc", img: "assets/a1.jpg" },
+      { name: "POP Ceiling", id: "pop", img: "assets/a4.jpg" }
 
     ]
   },
   {
     name: "Flooring",
     services: [
-      { name: "Vinyl Flooring", id: "vinyl" },
-      { name: "Wooden Flooring", id: "wooden" },
-      { name: "Carpet Tiles", id: "carpet" }
+      { name: "Vinyl Flooring", id: "vinyl", img: "assets/a7.jpg" },
+      { name: "Wooden Flooring", id: "wooden", img: "assets/a8.jpg" },
+      { name: "Tile Flooring", id: "tile", img: "assets/a9.jpg" },
+      { name: "Carpet Tiles", id: "carpet", img: "assets/a10.jpg" }
     ]
   },
   {
     name: "Blinds",
     services: [
-      { name: "Roller Blinds", id: "roller" },
-      { name: "Zebra Blinds", id: "zebra" },
-      { name: "Roman Blinds", id: "roman" },
-      { name: "PVC Blinds", id: "pvcb" },
-      { name: "Wooden Blinds", id: "woodb" },
-      { name: "Bambo Blinds", id: "bambo" }
+      { name: "Roller Blinds", id: "roller", img: "assets/a8.jpg" },
+      { name: "Zebra Blinds", id: "zebra", img: "assets/a11.jpg" },
+      { name: "Roman Blinds", id: "roman", img: "assets/a12.jpg" },
+      { name: "PVC Blinds", id: "pvcb", img: "assets/a13.jpg" },
+      { name: "Wooden Blinds", id: "woodb", img: "assets/a5.jpg" },
+      { name: "Bamboo Blinds", id: "bambo", img: "assets/a7.jpg" }
     ]
   },
   {
     name: "Aluminium Partitions",
     services: [
-      { name: "Office Partition", id: "officepart" },
-      { name: "Glass Partition", id: "glasspart" }
+      { name: "Office Partition", id: "officepart", img: "assets/a9.jpg" },
+      { name: "Glass Partition", id: "glasspart", img: "assets/a10.jpg" },
+      { name: "Cubicle Partition", id: "cubicle", img: "assets/a11.jpg" }
     ]
   },
   {
     name: "Aluminium Windows",
     services: [
-      { name: "Sliding Windows", id: "sliding1" },
-      { name: "Sliding windows", id: "sliding2" }
+      { name: "Sliding Windows", id: "sliding1", img: "assets/a5.jpg" },
+      { name: "Casement Windows", id: "casement", img: "assets/a4.jpg" },
+      { name: "Fixed Windows", id: "fixed", img: "assets/a6.jpg" }
     ]
   }
 ];

--- a/js/main.js
+++ b/js/main.js
@@ -106,11 +106,22 @@ document.addEventListener("DOMContentLoaded", () => {
 
       cat.services.forEach(item => {
         const li = document.createElement("li");
-        li.innerHTML = `<a href="products.html#${item.id}">${item.name}</a>`;
+        li.className = "sub-card";
+        li.innerHTML = `
+          <a href="products.html#${item.id}">
+            <img src="${item.img}" alt="${item.name}" />
+            <span>${item.name}</span>
+          </a>`;
         list.appendChild(li);
       });
 
       title.addEventListener("click", () => {
+        document.querySelectorAll(".service-category .sub-services").forEach(el => {
+          if (el !== list) el.classList.remove("open");
+        });
+        document.querySelectorAll(".service-category .category-title").forEach(el => {
+          if (el !== title) el.classList.remove("open");
+        });
         list.classList.toggle("open");
         title.classList.toggle("open");
       });

--- a/services.html
+++ b/services.html
@@ -44,34 +44,86 @@
   <section class="services-page">
     <div class="container">
       <h2 class="section-title">Our Services</h2>
-      <div class="services-grid">
-        <div class="service-card">
-          <img src="assets/a1.jpg" alt="False Ceiling" />
-          <h3>False Ceiling</h3>
-          <p>Elegant false ceiling installations tailored to your space.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a2.jpg" alt="Flooring" />
-          <h3>Flooring</h3>
-          <p>Premium flooring solutions for homes and offices.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a3.jpg" alt="Roller Screens" />
-          <h3>Roller Screens</h3>
-          <p>Sleek roller screens for privacy and aesthetics.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a4.jpg" alt="Partitions" />
-          <h3>Aluminium Partitions</h3>
-          <p>Modular partitions for smart office space design.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a5.jpg" alt="Windows" />
-          <h3>Aluminium Windows</h3>
-          <p>Durable and modern aluminium window fittings.</p>
-        </div>
-      </div>
+<div class="service-group">
+  <h3 class="service-group-title">Ceilings</h3>
+  <div class="services-grid">
+    <div class="service-card">
+      <img src="assets/a1.jpg" alt="False Ceiling" />
+      <h3>False Ceiling</h3>
+      <p>Elegant false ceiling installations tailored to your space.</p>
     </div>
+    <div class="service-card">
+      <img src="assets/a6.jpg" alt="Gypsum Ceiling" />
+      <h3>Gypsum Ceiling</h3>
+      <p>Smooth gypsum ceilings that elevate room acoustics and style.</p>
+    </div>
+  </div>
+</div>
+
+<div class="service-group">
+  <h3 class="service-group-title">Flooring</h3>
+  <div class="services-grid">
+    <div class="service-card">
+      <img src="assets/a2.jpg" alt="Flooring" />
+      <h3>Flooring</h3>
+      <p>Premium flooring solutions for homes and offices.</p>
+    </div>
+    <div class="service-card">
+      <img src="assets/a7.jpg" alt="Vinyl Flooring" />
+      <h3>Vinyl Flooring</h3>
+      <p>Durable vinyl flooring in a variety of modern designs.</p>
+    </div>
+  </div>
+</div>
+
+<div class="service-group">
+  <h3 class="service-group-title">Screens</h3>
+  <div class="services-grid">
+    <div class="service-card">
+      <img src="assets/a3.jpg" alt="Roller Screens" />
+      <h3>Roller Screens</h3>
+      <p>Sleek roller screens for privacy and aesthetics.</p>
+    </div>
+    <div class="service-card">
+      <img src="assets/a8.jpg" alt="Zebra Screens" />
+      <h3>Zebra Screens</h3>
+      <p>Modern zebra screens combining style and function.</p>
+    </div>
+  </div>
+</div>
+
+<div class="service-group">
+  <h3 class="service-group-title">Partitions</h3>
+  <div class="services-grid">
+    <div class="service-card">
+      <img src="assets/a4.jpg" alt="Aluminium Partitions" />
+      <h3>Aluminium Partitions</h3>
+      <p>Modular partitions for smart office space design.</p>
+    </div>
+    <div class="service-card">
+      <img src="assets/a9.jpg" alt="Glass Partitions" />
+      <h3>Glass Partitions</h3>
+      <p>Elegant glass partitions for a spacious open-office feel.</p>
+    </div>
+  </div>
+</div>
+
+<div class="service-group">
+  <h3 class="service-group-title">Windows</h3>
+  <div class="services-grid">
+    <div class="service-card">
+      <img src="assets/a5.jpg" alt="Aluminium Windows" />
+      <h3>Aluminium Windows</h3>
+      <p>Durable and modern aluminium window fittings.</p>
+    </div>
+    <div class="service-card">
+      <img src="assets/a10.jpg" alt="Sliding Windows" />
+      <h3>Sliding Windows</h3>
+      <p>Sleek sliding window systems for modern spaces.</p>
+    </div>
+  </div>
+  </div>
+</div>
   </section>
 
   <footer class="footer">
@@ -80,6 +132,7 @@
     </div>
   </footer>
 
+  <!-- Scripts -->
   <script>
   function toggleMenu() {
     document.getElementById("mobileNav").classList.toggle("active");


### PR DESCRIPTION
## Summary
- add service-group styles for grouped layouts
- reorganize service cards into categories like Ceilings and Screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853dc14d4048321bf9e9e8d5c4d3d87