### PR TITLE
Add decorative desktop experience tag section

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -6,8 +6,7 @@
   <title>Contact Us - AV Interior</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/css/style.css
+++ b/css/style.css
@@ -637,6 +637,56 @@ a {
   font-weight: 600;
 }
 
+/* DESKTOP EXPERIENCE TAG */
+.experience-tag-section {
+  position: relative;
+  height: 120px;
+  margin: var(--spacing-lg) 0;
+  display: none;
+}
+
+.experience-tag-section .shape-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.experience-tag-section .shape-divider {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 120px;
+  fill: #fdfdfd;
+}
+
+.experience-tag-section .shape-divider.top {
+  top: 0;
+}
+
+.experience-tag-section .shape-divider.bottom {
+  bottom: 0;
+  transform: rotate(180deg);
+}
+
+.experience-tag {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #b4845d;
+  color: #fff;
+  padding: 1rem 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  white-space: nowrap;
+}
+
+@media (min-width: 768px) {
+  .experience-tag-section {
+    display: block;
+  }
+}
+
 /* SERVICE LIST */
 .service-list {
   max-width: 600px;

--- a/css/style.css
+++ b/css/style.css
@@ -626,6 +626,8 @@ a {
 
 /* EXPERIENCE BANNER */
 .experience-banner {
+  position: relative;
+  overflow: hidden;
   background: linear-gradient(90deg, #ffffff, var(--primary-color));
   padding: var(--spacing-lg) 0;
   text-align: center;
@@ -637,53 +639,39 @@ a {
   font-weight: 600;
 }
 
-/* DESKTOP EXPERIENCE TAG */
-.experience-tag-section {
-  position: relative;
-  height: 180px;
-  margin: var(--spacing-lg) 0;
+/* DESKTOP EXPERIENCE DIVIDER */
+
+.experience-divider {
   display: none;
-}
-
-.experience-tag-section .shape-wrapper {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
-
-.experience-tag-section .shape-divider {
   position: absolute;
   left: 0;
+  bottom: -1px;
   width: 100%;
-  height: 120px;
+  height: 60px;
+  text-align: center;
+}
+
+.experience-divider svg {
+  width: 100%;
+  height: 100%;
   fill: #fdfdfd;
 }
 
-.experience-tag-section .shape-divider.top {
-  top: 0;
-  transform: translateY(-40px);
-}
-
-.experience-tag-section .shape-divider.bottom {
-  bottom: 0;
-  transform: rotate(180deg) translateY(-40px);
-}
-
-.experience-tag {
+.experience-badge {
   position: absolute;
-  top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  bottom: 28px;
+  transform: translateX(-50%);
   background: #b4845d;
   color: #fff;
-  padding: 1rem 2rem;
-  border-radius: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   white-space: nowrap;
 }
 
 @media (min-width: 768px) {
-  .experience-tag-section {
+  .experience-divider {
     display: block;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,7 @@
   /* Premium cream palette */
   --primary-color: #967859;
   --accent-color: #e6d9c7;
-  --cta-color: #b48a64;
+  --cta-color: #b4845d;
   --dark-color: #2f2b28;
   --text-color: #3b3328;
   --bg-light: #f7f3ef;
@@ -653,27 +653,48 @@ a {
   letter-spacing: -0.5px;
 }
 
-/* DESKTOP EXPERIENCE DIVIDER */
+/* DESKTOP EXPERIENCE TAG SECTION */
 
-.experience-divider {
+.experience-gap {
   display: none;
-  position: absolute;
-  left: 0;
-  bottom: -1px;
-  width: 100%;
-  height: 80px;
+  position: relative;
+  height: 150px;
   text-align: center;
 }
 
-.experience-divider svg {
+.exp-shape {
+  position: absolute;
+  left: 0;
   width: 100%;
-  height: 100%;
+  height: 150px;
   fill: var(--cta-color);
 }
 
+.exp-top {
+  top: 0;
+}
 
-@media (min-width: 1024px) {
-  .experience-divider {
+.exp-bottom {
+  bottom: 0;
+  transform: scaleY(-1);
+}
+
+.exp-tag {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--cta-color);
+  color: #fff;
+  padding: 1rem 2rem;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+@media (min-width: 768px) {
+  .experience-gap {
     display: block;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,11 +1,12 @@
 /* RESET & BASE */
 :root {
-  --primary-color: #a67c52;
-  --accent-color: #dbc8a0;
-  --cta-color: #b4845d;
-  --dark-color: #2e2b29;
-  --text-color: #2b2a28;
-  --bg-light: #f8f6f1;
+  /* Premium cream palette */
+  --primary-color: #967859;
+  --accent-color: #e6d9c7;
+  --cta-color: #b48a64;
+  --dark-color: #2f2b28;
+  --text-color: #3b3328;
+  --bg-light: #f7f3ef;
   --spacing-sm: 0.75rem;
   --spacing-md: 1.5rem;
   --spacing-lg: 3rem;

--- a/css/style.css
+++ b/css/style.css
@@ -640,10 +640,10 @@ a {
 .experience-banner {
   position: relative;
   overflow: hidden;
-  background: linear-gradient(90deg, #ffffff, var(--primary-color));
+  background: var(--cta-color);
   padding: calc(var(--spacing-lg) * 2) 0;
   text-align: center;
-  color: var(--dark-color);
+  color: #fff;
 }
 
 .experience-banner h3 {
@@ -660,14 +660,14 @@ a {
   left: 0;
   bottom: -1px;
   width: 100%;
-  height: 60px;
+  height: 80px;
   text-align: center;
 }
 
 .experience-divider svg {
   width: 100%;
   height: 100%;
-  fill: #fdfdfd;
+  fill: var(--cta-color);
 }
 
 
@@ -855,6 +855,9 @@ a {
 
 @media (max-width: 1023px) {
   .hero {
+    display: none;
+  }
+  .experience-banner {
     display: none;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -642,7 +642,7 @@ a {
 /* DESKTOP EXPERIENCE DIVIDER */
 
 .experience-divider {
-  display: none;
+  display: block;
   position: absolute;
   left: 0;
   bottom: -1px;
@@ -672,7 +672,7 @@ a {
 
 @media (min-width: 768px) {
   .experience-divider {
-    display: block;
+    display: none;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -223,7 +223,7 @@ a {
 .hero {
   position: relative;
   background: url('../assets/a1.jpg') center/cover no-repeat;
-  color: var(--dark-color);
+  color: #fff;
   min-height: 65vh;
   display: flex;
   flex-direction: column;
@@ -238,7 +238,7 @@ a {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.2));
+  background: linear-gradient(rgba(0,0,0,0.65), rgba(0,0,0,0.3));
   z-index: 0;
 }
 
@@ -251,11 +251,13 @@ a {
 .hero h2 {
   font-size: 2.5rem;
   margin-bottom: 1rem;
+  color: #fff;
   animation: fadeInUp 0.6s ease both;
 }
 .hero p {
   font-size: 1.2rem;
   margin-bottom: 2rem;
+  color: #fff;
   animation: fadeInUp 0.6s ease both;
   animation-delay: 0.1s;
 }
@@ -639,7 +641,7 @@ a {
   position: relative;
   overflow: hidden;
   background: linear-gradient(90deg, #ffffff, var(--primary-color));
-  padding: calc(var(--spacing-lg) * 1.2) 0;
+  padding: calc(var(--spacing-lg) * 2) 0;
   text-align: center;
   color: var(--dark-color);
 }
@@ -668,18 +670,6 @@ a {
   fill: #fdfdfd;
 }
 
-.experience-badge {
-  position: absolute;
-  left: 50%;
-  bottom: 28px;
-  transform: translateX(-50%);
-  background: #b4845d;
-  color: #fff;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  white-space: nowrap;
-}
 
 @media (min-width: 1024px) {
   .experience-divider {
@@ -860,5 +850,11 @@ a {
   .categories,
   .milestones {
     padding: calc(var(--spacing-lg) * 1.5) 0;
+  }
+}
+
+@media (max-width: 1023px) {
+  .hero {
+    display: none;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,7 @@
 :root {
   --primary-color: #a67c52;
   --accent-color: #dbc8a0;
+  --cta-color: #b4845d;
   --dark-color: #2e2b29;
   --text-color: #2b2a28;
   --bg-light: #f8f6f1;
@@ -21,6 +22,13 @@ body {
   font-size: 16px;
   letter-spacing: 0.2px;
 }
+h1, h2, h3, h4, h5, h6,
+.section-title,
+.logo,
+.service-group-title {
+  font-family: 'Poppins', sans-serif;
+  letter-spacing: -0.5px;
+}
 a {
   text-decoration: none;
   color: inherit;
@@ -31,16 +39,11 @@ a {
   margin: auto;
 }
 
-.container h2{
-  font-family: "DM Serif Text", serif;
-  font-weight: 400;
-  font-style: normal;
-}
+
 
 .section-title {
-  font-family:  "DM Serif Text", serif;
   font-size: 2.25rem;
-  font-weight: 400;
+  font-weight: 600;
   text-align: center;
   margin-bottom: var(--spacing-lg);
   color: var(--text-color);
@@ -48,14 +51,14 @@ a {
 
 /* NAVBAR */
 .navbar {
-  background: rgba(17, 17, 17, 0.9);
+  background: rgba(17, 17, 17, 0.6);
   color: #fff;
   padding: 0;
   position: sticky;
   top: 0;
   z-index: 999;
   height: 55px;
-  backdrop-filter: blur(15px);
+  backdrop-filter: blur(10px);
 }
 
 .nav-container {
@@ -106,7 +109,6 @@ a {
   gap: 0.6rem;
   font-size: 1.5rem;
   font-weight: bold;
-  font-family: 'DM Serif Text', serif;
   letter-spacing: 1px;
   color: var(--accent-color);
   text-decoration: none;
@@ -190,6 +192,11 @@ a {
   }
 }
 
+.fade-up {
+  opacity: 0;
+  animation: fadeInUp 0.6s ease forwards;
+}
+
 @keyframes blobMove {
   from {
     transform: translate(0, 0) scale(1);
@@ -215,7 +222,7 @@ a {
 /* HERO */
 .hero {
   position: relative;
-  background: url('../assets/hero.jpg') center/cover no-repeat;
+  background: url('../assets/a1.jpg') center/cover no-repeat;
   color: var(--dark-color);
   min-height: 65vh;
   display: flex;
@@ -231,8 +238,7 @@ a {
   content: '';
   position: absolute;
   inset: 0;
-  background: rgba(81, 184, 77, 0.432);
-  backdrop-filter: blur(20px);
+  background: linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.2));
   z-index: 0;
 }
 
@@ -295,7 +301,7 @@ a {
   left: 0;
   width: 100%;
   height: 60px;
-  fill: #fff;
+  fill: var(--primary-color);
   z-index: 1;
 }
 .hero-top-wave {
@@ -323,9 +329,10 @@ a {
 .hero .btn {
   margin: 0 var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(221, 235, 28, 0.651);
-  background:  #f3f3f3;
+  border-radius: 999px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  background: var(--cta-color);
+  color: #fff;
   transition: background 0.3s, box-shadow 0.3s, transform 0.3s;
   animation: fadeInUp 0.6s ease both;
   animation-delay: 0.2s;
@@ -337,9 +344,8 @@ a {
 }
 
 .hero .btn:hover {
-  background: var(--primary-color);
-  color: #fff;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  background: #a0734f;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
   transform: translateY(-2px);
 }
 
@@ -416,6 +422,11 @@ a {
   border-radius: 15px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
   transition: transform 0.3s ease;
+  cursor: pointer;
+}
+
+.carousel-item:hover img {
+  transform: scale(1.05);
 }
 
 .carousel-item img.enlarged {
@@ -475,7 +486,6 @@ a {
   margin-bottom: var(--spacing-lg);
 }
 .service-group-title {
-  font-family: "DM Serif Text", serif;
   font-size: 1.75rem;
   margin-bottom: var(--spacing-md);
   color: var(--text-color);
@@ -629,20 +639,21 @@ a {
   position: relative;
   overflow: hidden;
   background: linear-gradient(90deg, #ffffff, var(--primary-color));
-  padding: var(--spacing-lg) 0;
+  padding: calc(var(--spacing-lg) * 1.2) 0;
   text-align: center;
   color: var(--dark-color);
 }
 
 .experience-banner h3 {
   font-size: 1.8rem;
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: -0.5px;
 }
 
 /* DESKTOP EXPERIENCE DIVIDER */
 
 .experience-divider {
-  display: block;
+  display: none;
   position: absolute;
   left: 0;
   bottom: -1px;
@@ -670,9 +681,9 @@ a {
   white-space: nowrap;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .experience-divider {
-    display: none;
+    display: block;
   }
 }
 
@@ -813,12 +824,6 @@ a {
   .hero-blob {
     display: block;
   }
-  .hero-wave {
-    display: block;
-  }
-  .hero-top-wave {
-    display: block;
-  }
   .hero-actions {
     flex-direction: column;
     align-items: center;
@@ -835,4 +840,25 @@ a {
     align-items: center;
   }
 
+}
+
+@media (min-width: 1024px) {
+  .hero-wave {
+    display: block;
+  }
+  .hero {
+    min-height: 80vh;
+    padding: 0 0 calc(var(--spacing-lg) * 1.5);
+  }
+  .hero h2 {
+    font-size: 3rem;
+  }
+  .section-title {
+    font-size: 2.5rem;
+  }
+  .carousel-section,
+  .categories,
+  .milestones {
+    padding: calc(var(--spacing-lg) * 1.5) 0;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -367,21 +367,6 @@ a {
   overflow: hidden;
   width: 100%;
 }
-.wave {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 60px;
-  fill: #fff;
-  z-index: 1;
-}
-.wave-top {
-  top: -1px;
-  transform: rotate(180deg);
-}
-.wave-bottom {
-  bottom: -1px;
-}
 .carousel-section .section-title,
 .carousel-section .carousel-subtext {
   text-align: center;
@@ -653,51 +638,6 @@ a {
   letter-spacing: -0.5px;
 }
 
-/* DESKTOP EXPERIENCE TAG SECTION */
-
-.experience-gap {
-  display: none;
-  position: relative;
-  height: 150px;
-  text-align: center;
-}
-
-.exp-shape {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 150px;
-  fill: var(--cta-color);
-}
-
-.exp-top {
-  top: 0;
-}
-
-.exp-bottom {
-  bottom: 0;
-  transform: scaleY(-1);
-}
-
-.exp-tag {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: var(--cta-color);
-  color: #fff;
-  padding: 1rem 2rem;
-  border-radius: 999px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-@media (min-width: 768px) {
-  .experience-gap {
-    display: block;
-  }
-}
 
 /* SERVICE LIST */
 .service-list {

--- a/css/style.css
+++ b/css/style.css
@@ -640,7 +640,7 @@ a {
 /* DESKTOP EXPERIENCE TAG */
 .experience-tag-section {
   position: relative;
-  height: 160px;
+  height: 180px;
   margin: var(--spacing-lg) 0;
   display: none;
 }
@@ -661,12 +661,12 @@ a {
 
 .experience-tag-section .shape-divider.top {
   top: 0;
-  transform: translateY(-20px);
+  transform: translateY(-40px);
 }
 
 .experience-tag-section .shape-divider.bottom {
   bottom: 0;
-  transform: rotate(180deg) translateY(-20px);
+  transform: rotate(180deg) translateY(-40px);
 }
 
 .experience-tag {

--- a/css/style.css
+++ b/css/style.css
@@ -640,7 +640,7 @@ a {
 /* DESKTOP EXPERIENCE TAG */
 .experience-tag-section {
   position: relative;
-  height: 120px;
+  height: 160px;
   margin: var(--spacing-lg) 0;
   display: none;
 }
@@ -661,11 +661,12 @@ a {
 
 .experience-tag-section .shape-divider.top {
   top: 0;
+  transform: translateY(-20px);
 }
 
 .experience-tag-section .shape-divider.bottom {
   bottom: 0;
-  transform: rotate(180deg);
+  transform: rotate(180deg) translateY(-20px);
 }
 
 .experience-tag {

--- a/index.html
+++ b/index.html
@@ -72,11 +72,16 @@
     <div class="container">
       <h3>10+ Years of Experience</h3>
     </div>
-    <div class="experience-divider" aria-hidden="true">
-      <svg viewBox="0 0 1440 80" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0,0 C360,60 1080,60 1440,0 V80 H0 V0 Z" />
-      </svg>
-    </div>
+  </section>
+
+  <section class="experience-gap">
+    <svg class="exp-shape exp-top" viewBox="0 0 1200 120" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
+    </svg>
+    <span class="exp-tag">10+ Years of Experience</span>
+    <svg class="exp-shape exp-bottom" viewBox="0 0 1200 120" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
+    </svg>
   </section>
 
   <!-- Carousel Section -->

--- a/index.html
+++ b/index.html
@@ -79,11 +79,11 @@
   <section class="experience-tag-section" aria-hidden="true">
     <div class="shape-wrapper">
       <svg class="shape-divider top" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0,40 C300,80 900,80 1200,40 L1200,0 L0,0 Z" />
+        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
       </svg>
       <span class="experience-tag">10+ Years of Experience</span>
       <svg class="shape-divider bottom" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0,40 C300,80 900,80 1200,40 L1200,0 L0,0 Z" />
+        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
       </svg>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -74,15 +74,6 @@
     </div>
   </section>
 
-  <section class="experience-gap">
-    <svg class="exp-shape exp-top" viewBox="0 0 1200 120" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
-    </svg>
-    <span class="exp-tag">10+ Years of Experience</span>
-    <svg class="exp-shape exp-bottom" viewBox="0 0 1200 120" preserveAspectRatio="none" aria-hidden="true">
-      <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
-    </svg>
-  </section>
 
   <!-- Carousel Section -->
   <section class="carousel-section">
@@ -97,9 +88,6 @@
         <span>Scroll to view gallery</span>
         <span class="down-arrow">&#8595;</span>
       </div>
-      <svg class="wave wave-bottom" viewBox="0 0 1440 60" preserveAspectRatio="none" aria-hidden="true">
-        <path d="M0,0 C150,30 300,60 450,30 C600,0 750,0 900,30 C1050,60 1200,30 1440,0 V60 H0 V0 Z" />
-      </svg>
   </section>
 
   <!-- Categories Section -->

--- a/index.html
+++ b/index.html
@@ -8,8 +8,7 @@
   <!-- Styles -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -56,15 +55,15 @@
     </div>
     <div class="hero-blob" aria-hidden="true"></div>
     <div class="container hero-content">
-      <h2>Your Dream Space, Realized</h2>
-      <p>Premium interior decoration for homes and offices. Expertly done. Perfectly delivered.</p>
-      <div class="hero-actions">
+      <h2 class="fade-up">Your Dream Space, Realized</h2>
+      <p class="fade-up" style="animation-delay:0.1s">Premium interior decoration for homes and offices. Expertly done. Perfectly delivered.</p>
+      <div class="hero-actions fade-up" style="animation-delay:0.2s">
         <a href="services.html" class="btn" aria-label="Explore our services">Explore Our Services</a>
         <a href="contact.html" class="btn" aria-label="Contact us">Contact Us</a>
       </div>
     </div>
-    <svg class="hero-wave transition duration-300 ease-in-out delay-150" width="100%" height="100%" id="svg" viewBox="0 0 1440 390" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <path d="M 0,400 L 0,0 C 147.7333333333333,38 295.4666666666666,76 472,100 C 648.5333333333334,124 853.8666666666668,134 1020,115 C 1186.1333333333332,95.99999999999999 1313.0666666666666,47.99999999999999 1440,0 L 1440,400 L 0,400 Z" stroke="none" stroke-width="0" fill="#fff" fill-opacity="1" class="transition-all duration-300 ease-in-out delay-150 path-0" />
+    <svg class="hero-wave" width="100%" height="100%" viewBox="0 0 1440 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M0,0 C480,80 960,80 1440,0 V120 H0 V0 Z" />
     </svg>
   </section>
 
@@ -74,7 +73,7 @@
       <h3>10+ Years of Experience in Interior & Exterior Decoration</h3>
     </div>
     <div class="experience-divider" aria-hidden="true">
-      <span class="experience-badge">10+ Years of Experience</span>
+      <span class="experience-badge fade-up" style="animation-delay:0.1s">10+ Years of Experience</span>
       <svg viewBox="0 0 1440 60" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M0,60 C150,30 300,0 450,30 C600,60 750,60 900,30 C1050,0 1200,30 1440,60 V0 H0 V60 Z" />
       </svg>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,19 @@
     </div>
 </section>
 
+  <!-- Experience Star Tag -->
+  <section class="experience-tag-section" aria-hidden="true">
+    <div class="shape-wrapper">
+      <svg class="shape-divider top" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z"/>
+      </svg>
+      <span class="experience-tag">10+ Years of Experience</span>
+      <svg class="shape-divider bottom" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z"/>
+      </svg>
+    </div>
+  </section>
+
   <!-- Carousel Section -->
   <section class="carousel-section">
       <svg class="wave wave-top" viewBox="0 0 1440 60" preserveAspectRatio="none" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -70,10 +70,9 @@
   <!-- Experience Banner -->
   <section class="experience-banner">
     <div class="container">
-      <h3>10+ Years of Experience in Interior & Exterior Decoration</h3>
+      <h3>10+ Years of Experience</h3>
     </div>
     <div class="experience-divider" aria-hidden="true">
-      <span class="experience-badge fade-up" style="animation-delay:0.1s">10+ Years of Experience</span>
       <svg viewBox="0 0 1440 60" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M0,60 C150,30 300,0 450,30 C600,60 750,60 900,30 C1050,0 1200,30 1440,60 V0 H0 V60 Z" />
       </svg>

--- a/index.html
+++ b/index.html
@@ -73,17 +73,10 @@
     <div class="container">
       <h3>10+ Years of Experience in Interior & Exterior Decoration</h3>
     </div>
-</section>
-
-  <!-- Experience Star Tag -->
-  <section class="experience-tag-section" aria-hidden="true">
-    <div class="shape-wrapper">
-      <svg class="shape-divider top" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
-      </svg>
-      <span class="experience-tag">10+ Years of Experience</span>
-      <svg class="shape-divider bottom" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z" />
+    <div class="experience-divider" aria-hidden="true">
+      <span class="experience-badge">10+ Years of Experience</span>
+      <svg viewBox="0 0 1440 60" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M0,60 C150,30 300,0 450,30 C600,60 750,60 900,30 C1050,0 1200,30 1440,60 V0 H0 V60 Z" />
       </svg>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -73,17 +73,14 @@
       <h3>10+ Years of Experience</h3>
     </div>
     <div class="experience-divider" aria-hidden="true">
-      <svg viewBox="0 0 1440 60" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0,60 C150,30 300,0 450,30 C600,60 750,60 900,30 C1050,0 1200,30 1440,60 V0 H0 V60 Z" />
+      <svg viewBox="0 0 1440 80" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M0,0 C360,60 1080,60 1440,0 V80 H0 V0 Z" />
       </svg>
     </div>
   </section>
 
   <!-- Carousel Section -->
   <section class="carousel-section">
-      <svg class="wave wave-top" viewBox="0 0 1440 60" preserveAspectRatio="none" aria-hidden="true">
-        <path d="M0,60 C150,30 300,0 450,30 C600,60 750,60 900,30 C1050,0 1200,30 1440,60 V0 H0 V60 Z" />
-      </svg>
       <h2 class="section-title">Our Project Highlights</h2>
       <p class="carousel-subtext">A glimpse of our recent work</p>
       <div class="carousel-container" id="carousel-container">

--- a/index.html
+++ b/index.html
@@ -79,11 +79,11 @@
   <section class="experience-tag-section" aria-hidden="true">
     <div class="shape-wrapper">
       <svg class="shape-divider top" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z"/>
+        <path d="M0,40 C300,80 900,80 1200,40 L1200,0 L0,0 Z" />
       </svg>
       <span class="experience-tag">10+ Years of Experience</span>
       <svg class="shape-divider bottom" viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M602.45,3.86h0S572.9,116.24,281.94,120H923C632,116.24,602.45,3.86,602.45,3.86Z"/>
+        <path d="M0,40 C300,80 900,80 1200,40 L1200,0 L0,0 Z" />
       </svg>
     </div>
   </section>

--- a/js/main.js
+++ b/js/main.js
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (carouselTrack && carouselContainer) {
     projectImages.forEach(project => {
       const slide = document.createElement("div");
-      slide.className = "carousel-item";
+      slide.className = "carousel-item fade-up";
       slide.innerHTML = `<img src="${project.src}" alt="${project.alt}">`;
       carouselTrack.appendChild(slide);
     });

--- a/services.html
+++ b/services.html
@@ -6,8 +6,7 @@
   <title>Our Services - AV Interior</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a new desktop-only experience tag section with stacked SVG dividers
- style the new section in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3747ff7883218b2d83643ba92bcb