### PR TITLE
Adjust hero overlay visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -236,6 +236,14 @@ a {
   z-index: 0;
 }
 
+@media (min-width: 769px) {
+  .hero::before {
+    content: none;
+    background: none;
+    backdrop-filter: none;
+  }
+}
+
 
 .hero .container {
   position: relative;


### PR DESCRIPTION
## Summary
- limit hero section's green overlay to mobile screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860dbce4c7883219a4769df8c5de0ad