### PR TITLE
Revamp hero layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -215,7 +215,7 @@ a {
 /* HERO */
 .hero {
   position: relative;
-  background: var(--bg-light);
+  background: url('../assets/hero.jpg') center/cover no-repeat;
   color: var(--dark-color);
   min-height: 65vh;
   display: flex;
@@ -228,7 +228,12 @@ a {
 
 
 .hero::before {
-  display: none;
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(81, 184, 77, 0.432);
+  backdrop-filter: blur(20px);
+  z-index: 0;
 }
 
 
@@ -272,7 +277,7 @@ a {
 }
 
 .hero-carousel {
-  display: block;
+  display: none;
   width: 100%;
   overflow: hidden;
 }
@@ -768,7 +773,7 @@ a {
     margin-bottom: 1.2rem;
   }
   .hero {
-    background: var(--bg-light);
+    background: none;
     padding: 0 0 var(--spacing-md);
   }
   .hero-carousel {
@@ -819,6 +824,10 @@ a {
   .hero {
     min-height: 70vh;
     background: var(--bg-light);
+  }
+
+  .hero::before {
+    display: none;
   }
 
   .hero-carousel {

--- a/css/style.css
+++ b/css/style.css
@@ -215,7 +215,7 @@ a {
 /* HERO */
 .hero {
   position: relative;
-  background: url('../assets/hero.jpg') center/cover no-repeat;
+  background: var(--bg-light);
   color: var(--dark-color);
   min-height: 65vh;
   display: flex;
@@ -228,12 +228,7 @@ a {
 
 
 .hero::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(81, 184, 77, 0.432);
-  backdrop-filter: blur(20px);
-  z-index: 0;
+  display: none;
 }
 
 
@@ -270,8 +265,14 @@ a {
   gap: var(--spacing-sm);
 }
 
+.hero-carousel-wrapper {
+  position: relative;
+  z-index: 1;
+  margin: var(--spacing-md) auto;
+}
+
 .hero-carousel {
-  display: none;
+  display: block;
   width: 100%;
   overflow: hidden;
 }
@@ -767,7 +768,7 @@ a {
     margin-bottom: 1.2rem;
   }
   .hero {
-    background: none;
+    background: var(--bg-light);
     padding: 0 0 var(--spacing-md);
   }
   .hero-carousel {
@@ -817,7 +818,7 @@ a {
 @media (min-width: 769px) {
   .hero {
     min-height: 70vh;
-    background: none;
+    background: var(--bg-light);
   }
 
   .hero-carousel {

--- a/index.html
+++ b/index.html
@@ -46,14 +46,16 @@
 
   <!-- Hero Section -->
   <section class="hero">
-    <div class="hero-carousel" id="hero-carousel">
-      <div class="slides">
-        <img src="assets/a1.jpg" alt="Project photo 1" />
-        <img src="assets/a2.jpg" alt="Project photo 2" />
-        <img src="assets/a3.jpg" alt="Project photo 3" />
-        <img src="assets/a4.jpg" alt="Project photo 4" />
-        <img src="assets/a5.jpg" alt="Project photo 5" />
-        <img src="assets/a6.jpg" alt="Project photo 6" />
+    <div class="container hero-carousel-wrapper">
+      <div class="hero-carousel" id="hero-carousel">
+        <div class="slides">
+          <img src="assets/a1.jpg" alt="Project photo 1" />
+          <img src="assets/a2.jpg" alt="Project photo 2" />
+          <img src="assets/a3.jpg" alt="Project photo 3" />
+          <img src="assets/a4.jpg" alt="Project photo 4" />
+          <img src="assets/a5.jpg" alt="Project photo 5" />
+          <img src="assets/a6.jpg" alt="Project photo 6" />
+        </div>
       </div>
     </div>
     <div class="hero-blob" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- apply 90% width container around hero carousel
- set hero background to match divider color
- hide hero overlay and display carousel on all breakpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68610290c3c8832197bc99c76146829d