### PR TITLE
Center hero content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -220,8 +220,9 @@ a {
   min-height: 65vh;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  padding: 0 0 var(--spacing-lg);
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacing-lg) var(--spacing-md);
   text-align: center;
   overflow: hidden;
 }
@@ -233,7 +234,7 @@ a {
   inset: 0;
   background: rgba(81, 184, 77, 0.432);
   backdrop-filter: blur(20px);
-  z-index: 0;
+  z-index: 1;
 }
 
 
@@ -271,9 +272,13 @@ a {
 }
 
 .hero-carousel {
+  position: absolute;
+  inset: 0;
   display: none;
   width: 100%;
+  height: 100%;
   overflow: hidden;
+  z-index: 0;
 }
 .hero-blob {
   display: none;
@@ -316,12 +321,13 @@ a {
 .hero-carousel .slides {
   filter: blur(3px);
   display: flex;
+  height: 100%;
   transition: transform 0.5s ease-in-out;
 }
 .hero-carousel img {
   flex: 0 0 100%;
   width: 100%;
-  height: 240px;
+  height: 100%;
   object-fit: cover;
   animation: heroZoom 20s ease-in-out infinite;
 }
@@ -769,6 +775,7 @@ a {
   .hero {
     background: none;
     padding: 0 0 var(--spacing-md);
+    justify-content: flex-end;
   }
   .hero-carousel {
     display: block;
@@ -776,7 +783,7 @@ a {
  .hero-content {
   position: relative;
   z-index: 1;
-  margin: var(--spacing-md) auto;
+  margin: var(--spacing-md) auto var(--spacing-lg);
   padding: var(--spacing-md);
   background: rgba(252, 246, 246, 0.603); /* light frosted glass */
   backdrop-filter: blur(16px);

--- a/js/main.js
+++ b/js/main.js
@@ -138,6 +138,10 @@ document.addEventListener("DOMContentLoaded", () => {
       wrapper.appendChild(title);
       wrapper.appendChild(list);
       serviceListEl.appendChild(wrapper);
+      // open each category by default
+      list.classList.add("open");
+      title.classList.add("open");
+      list.style.maxHeight = list.scrollHeight + "px";
     });
   }
 });

--- a/services.html
+++ b/services.html
@@ -42,79 +42,70 @@
 
 
   <section class="services-page">
-        <div class="service-group">
-            <div class="container">
-          <h3 class="service-group-title">Flooring</h3>
-          <div class="services-grid">
-            <div class="service-card">
-              <img src="assets/a2.jpg" alt="Flooring" />
-              <h3>Flooring</h3>
-              <p>Premium flooring solutions for homes and offices.</p>
-            </div>
-            <div class="service-card">
-              <img src="assets/a7.jpg" alt="Vinyl Flooring" />
-              <h3>Vinyl Flooring</h3>
-              <p>Durable vinyl flooring in a variety of modern designs.</p>
-            </div>
-          </div>
-          </div>
+    <div class="container">
+      <h2 class="section-title">Our Services</h2>
+      <div class="services-grid">
+        <div class="service-card">
+          <img src="assets/a1.jpg" alt="False Ceiling" />
+          <h3>False Ceiling</h3>
+          <p>Elegant false ceiling installations tailored to your space.</p>
         </div>
-
-        <div class="service-group">
-            <div class="container">
-          <h3 class="service-group-title">Screens</h3>
-          <div class="services-grid">
-            <div class="service-card">
-              <img src="assets/a3.jpg" alt="Roller Screens" />
-              <h3>Roller Screens</h3>
-              <p>Sleek roller screens for privacy and aesthetics.</p>
-            </div>
-            <div class="service-card">
-              <img src="assets/a8.jpg" alt="Zebra Screens" />
-              <h3>Zebra Screens</h3>
-              <p>Modern zebra screens combining style and function.</p>
-            </div>
-            </div>
-          </div>
+        <div class="service-card">
+          <img src="assets/a2.jpg" alt="Flooring" />
+          <h3>Flooring</h3>
+          <p>Premium flooring solutions for homes and offices.</p>
         </div>
-
-
-        <div class="service-group">
-            <div class="container">
-          <h3 class="service-group-title">Partitions</h3>
-          <div class="services-grid">
-            <div class="service-card">
-              <img src="assets/a4.jpg" alt="Aluminium Partitions" />
-              <h3>Aluminium Partitions</h3>
-              <p>Modular partitions for smart office space design.</p>
-            </div>
-            <div class="service-card">
-              <img src="assets/a9.jpg" alt="Glass Partitions" />
-              <h3>Glass Partitions</h3>
-              <p>Elegant glass partitions for a spacious open-office feel.</p>
-            </div>
-            </div>
-          </div>
+        <div class="service-card">
+          <img src="assets/a3.jpg" alt="Roller Screens" />
+          <h3>Roller Screens</h3>
+          <p>Sleek roller screens for privacy and aesthetics.</p>
         </div>
+        <div class="service-card">
+          <img src="assets/a4.jpg" alt="Partitions" />
+          <h3>Aluminium Partitions</h3>
+          <p>Modular partitions for smart office space design.</p>
+        </div>
+        <div class="service-card">
+          <img src="assets/a5.jpg" alt="Windows" />
+          <h3>Aluminium Windows</h3>
+          <p>Durable and modern aluminium window fittings.</p>
+        </div>
+        <!-- Additional services -->
+        <div class="service-card">
+          <img src="assets/a6.jpg" alt="Gypsum Ceiling" />
+          <h3>Gypsum Ceiling</h3>
+          <p>Smooth gypsum ceilings that elevate room acoustics and style.</p>
+        </div>
+        <div class="service-card">
+          <img src="assets/a7.jpg" alt="Vinyl Flooring" />
+          <h3>Vinyl Flooring</h3>
+          <p>Durable vinyl flooring in a variety of modern designs.</p>
+        </div>
+        <div class="service-card">
+          <img src="assets/a8.jpg" alt="Roller Blinds" />
+          <h3>Roller Blinds</h3>
+          <p>Custom roller blinds for light control and privacy.</p>
+        </div>
+        <div class="service-card">
+          <img src="assets/a9.jpg" alt="Glass Partitions" />
+          <h3>Glass Partitions</h3>
+          <p>Elegant glass partitions for a spacious open-office feel.</p>
+        </div>
+        <div class="service-card">
+          <img src="assets/a10.jpg" alt="Sliding Windows" />
+          <h3>Sliding Windows</h3>
+          <p>Sleek sliding window systems for modern spaces.</p>
+        </div>
+      </div>
+    </div>
+  </section>
 
-        <div class="service-group">
-            <div class="container">
-          <h3 class="service-group-title">Windows</h3>
-          <div class="services-grid">
-            <div class="service-card">
-              <img src="assets/a5.jpg" alt="Aluminium Windows" />
-              <h3>Aluminium Windows</h3>
-              <p>Durable and modern aluminium window fittings.</p>
-            </div>
-            <div class="service-card">
-              <img src="assets/a10.jpg" alt="Sliding Windows" />
-              <h3>Sliding Windows</h3>
-              <p>Sleek sliding window systems for modern spaces.</p>
-            </div>
-            </div>
-          </div>
-          </div>
-
+  <!-- Categories Section -->
+  <section class="categories">
+    <div class="container">
+      <h2 class="section-title">Service Categories</h2>
+      <div class="service-list" id="service-list"></div>
+    </div>
   </section>
 
   <footer class="footer">
@@ -124,13 +115,13 @@
   </footer>
 
   <!-- Scripts -->
+  <script src="js/data.js"></script>
+  <script src="js/main.js"></script>
   <script>
- function toggleMenu() {
-    const menu = document.getElementById("mobileNav");
+  function toggleMenu() {
+    document.getElementById("mobileNav").classList.toggle("active");
     const btn = document.querySelector('.menu-icon');
-    menu.classList.toggle("active");
     if (btn) {
-      btn.classList.toggle("active");
       const expanded = btn.getAttribute('aria-expanded') === 'true';
       btn.setAttribute('aria-expanded', !expanded);
     }


### PR DESCRIPTION
## Summary
- center hero content in the hero section
- overlay hero carousel as a background
- ensure images and slides fill available space
- revert mobile hero carousel sizing to original
- lower hero content on mobile
- show all service categories on the services page
- display service subcategories expanded by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686106ad3cd88321bd3e14bbe4e22da9