### PR TITLE
Add dynamic services modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -488,6 +488,31 @@ a {
 .services-page {
   padding: var(--spacing-lg) 0;
 }
+.filter-controls {
+  text-align: center;
+  margin-bottom: var(--spacing-md);
+}
+
+.filter-btn {
+  background: var(--accent-color);
+  border: none;
+  color: var(--dark-color);
+  padding: 0.5rem 1rem;
+  margin: 0 0.25rem 0.5rem;
+  border-radius: 20px;
+  font-weight: 500;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s, transform 0.3s;
+}
+
+.filter-btn.active,
+.filter-btn:hover {
+  background: var(--primary-color);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
 .service-group {
   background: #fff;
   padding: var(--spacing-md);
@@ -503,18 +528,39 @@ a {
 }
 .services-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 2rem;
+  grid-template-columns: 1fr;
 }
+
+@media (min-width: 600px) {
+  .services-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .services-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .services-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
 .service-card {
   background: #fff;
-  border-radius: 10px;
-  box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 1rem;
-  transition: transform 0.3s;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 .service-card:hover {
   transform: translateY(-5px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
 }
 .service-card img {
   width: 100%;
@@ -531,6 +577,95 @@ a {
 .service-card p {
   font-size: 0.95rem;
   color: #666;
+}
+
+.service-card .details-toggle {
+  margin-top: 0.75rem;
+  background: var(--accent-color);
+  color: var(--dark-color);
+  border: none;
+  border-radius: 20px;
+  padding: 0.45rem 1rem;
+  font-weight: 500;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s, transform 0.3s;
+  display: inline-block;
+}
+
+.service-card .details-toggle:hover {
+  background: var(--primary-color);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
+
+.service-card.expanded {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+/* SERVICE MODAL */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal.open {
+  display: flex;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 12px;
+  max-width: 800px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 1.5rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.sub-item-card {
+  text-align: center;
+}
+
+.sub-item-card img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+}
+
+.sub-item-card h4 {
+  font-size: 1rem;
+  color: #333;
 }
 
 /* PROJECTS */

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,12 @@ document.addEventListener("DOMContentLoaded", () => {
   const carouselTrack = document.getElementById("carousel-track");
   const carouselContainer = document.getElementById("carousel-container");
   const serviceListEl = document.getElementById("service-list");
+  const servicesGrid = document.getElementById("servicesGrid");
+  const filterControls = document.getElementById("filterControls");
+  const servicesModal = document.getElementById("servicesModal");
+  const modalGrid = document.getElementById("modalGrid");
+  const modalTitle = document.getElementById("modalTitle");
+  const modalClose = document.querySelector(".modal-close");
   const heroCarousel = document.getElementById("hero-carousel");
 
   if (heroCarousel) {
@@ -139,5 +145,94 @@ document.addEventListener("DOMContentLoaded", () => {
       wrapper.appendChild(list);
       serviceListEl.appendChild(wrapper);
     });
+  }
+
+  if (servicesGrid) {
+    const descriptions = {
+      "Cupboards": "Modular kitchens and custom storage solutions.",
+      "Glass Works": "Quality glass partitions and railings.",
+      "Blinds": "Range of blinds and curtains for every need.",
+      "False Ceiling": "Stylish designs to enhance your interiors.",
+      "MosquitoNet": "Durable nets for doors and windows.",
+      "Flooring": "Vinyl, wooden and carpet options.",
+      "Aluminium works": "Partitions, windows and more.",
+      "UPVC Work": "UPVC windows, doors and partitions."
+    };
+
+    const frag = document.createDocumentFragment();
+    const allBtn = document.createElement("button");
+    allBtn.className = "filter-btn active";
+    allBtn.dataset.filter = "all";
+    allBtn.textContent = "All";
+    frag.appendChild(allBtn);
+
+    serviceList.forEach(cat => {
+      const btn = document.createElement("button");
+      btn.className = "filter-btn";
+      btn.dataset.filter = cat.name;
+      btn.textContent = cat.name;
+      frag.appendChild(btn);
+    });
+    if (filterControls) filterControls.appendChild(frag);
+
+    serviceList.forEach(cat => {
+      const card = document.createElement("div");
+      card.className = "service-card";
+      card.dataset.category = cat.name;
+      const first = cat.services[0];
+      card.innerHTML = `
+        <img src="${first.img}" alt="${cat.name}">
+        <h3>${cat.name}</h3>
+        <p>${descriptions[cat.name] || `Explore our ${cat.name.toLowerCase()} solutions.`}</p>
+        <button class="details-toggle btn">View Details</button>
+      `;
+
+      const toggleBtn = card.querySelector(".details-toggle");
+      toggleBtn.addEventListener("click", e => {
+        e.preventDefault();
+        if (!(servicesModal && modalGrid && modalTitle)) return;
+        modalTitle.textContent = cat.name;
+        modalGrid.innerHTML = "";
+        cat.services.forEach(item => {
+          const div = document.createElement("div");
+          div.className = "sub-item-card";
+          div.innerHTML = `
+            <img src="${item.img}" alt="${item.name}">
+            <h4>${item.name}</h4>
+          `;
+          modalGrid.appendChild(div);
+        });
+        servicesModal.classList.add("open");
+        document.body.style.overflow = "hidden";
+      });
+
+      servicesGrid.appendChild(card);
+    });
+
+    if (filterControls) {
+      filterControls.addEventListener("click", e => {
+        const btn = e.target.closest(".filter-btn");
+        if (!btn) return;
+        filterControls.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+        const filter = btn.dataset.filter;
+        servicesGrid.querySelectorAll(".service-card").forEach(card => {
+          const show = filter === "all" || card.dataset.category === filter;
+          card.style.display = show ? "" : "none";
+        });
+      });
+    }
+
+    if (modalClose && servicesModal) {
+      const closeModal = () => {
+        servicesModal.classList.remove("open");
+        modalGrid.innerHTML = "";
+        document.body.style.overflow = "";
+      };
+      modalClose.addEventListener("click", closeModal);
+      servicesModal.addEventListener("click", e => {
+        if (e.target === servicesModal) closeModal();
+      });
+    }
   }
 });

--- a/services.html
+++ b/services.html
@@ -44,61 +44,18 @@
   <section class="services-page">
     <div class="container">
       <h2 class="section-title">Our Services</h2>
-      <div class="services-grid">
-        <div class="service-card">
-          <img src="assets/a1.jpg" alt="False Ceiling" />
-          <h3>False Ceiling</h3>
-          <p>Elegant false ceiling installations tailored to your space.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a2.jpg" alt="Flooring" />
-          <h3>Flooring</h3>
-          <p>Premium flooring solutions for homes and offices.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a3.jpg" alt="Roller Screens" />
-          <h3>Roller Screens</h3>
-          <p>Sleek roller screens for privacy and aesthetics.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a4.jpg" alt="Partitions" />
-          <h3>Aluminium Partitions</h3>
-          <p>Modular partitions for smart office space design.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a5.jpg" alt="Windows" />
-          <h3>Aluminium Windows</h3>
-          <p>Durable and modern aluminium window fittings.</p>
-        </div>
-        <!-- Additional services -->
-        <div class="service-card">
-          <img src="assets/a6.jpg" alt="Gypsum Ceiling" />
-          <h3>Gypsum Ceiling</h3>
-          <p>Smooth gypsum ceilings that elevate room acoustics and style.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a7.jpg" alt="Vinyl Flooring" />
-          <h3>Vinyl Flooring</h3>
-          <p>Durable vinyl flooring in a variety of modern designs.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a8.jpg" alt="Roller Blinds" />
-          <h3>Roller Blinds</h3>
-          <p>Custom roller blinds for light control and privacy.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a9.jpg" alt="Glass Partitions" />
-          <h3>Glass Partitions</h3>
-          <p>Elegant glass partitions for a spacious open-office feel.</p>
-        </div>
-        <div class="service-card">
-          <img src="assets/a10.jpg" alt="Sliding Windows" />
-          <h3>Sliding Windows</h3>
-          <p>Sleek sliding window systems for modern spaces.</p>
-        </div>
-      </div>
+      <div id="filterControls" class="filter-controls"></div>
+      <div class="services-grid" id="servicesGrid"></div>
     </div>
   </section>
+
+  <div class="modal" id="servicesModal" aria-hidden="true">
+    <div class="modal-content">
+      <button class="modal-close" aria-label="Close">&times;</button>
+      <h3 id="modalTitle"></h3>
+      <div class="modal-grid" id="modalGrid"></div>
+    </div>
+  </div>
 
 
   <footer class="footer">


### PR DESCRIPTION
## Summary
- implement popup modal for viewing service sub-items
- style the modal with responsive grid mini-cards
- hook up modal logic in JavaScript and update services page markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68623d244db08321adc9d2178223d3e2