### PR TITLE
Add modal view for service sub-items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -932,3 +932,69 @@ a {
   }
 }
 
+/* Modal Styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal.open {
+  display: flex;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 800px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  width: 90%;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modal-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.sub-item-card {
+  text-align: center;
+  border: 1px solid var(--accent-color);
+  border-radius: 6px;
+  padding: 0.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+.sub-item-card img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 0.25rem;
+}
+
+.sub-item-card h4 {
+  font-size: 0.95rem;
+  margin-top: 0.25rem;
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,34 @@ document.addEventListener("DOMContentLoaded", () => {
   const servicesGrid = document.getElementById("servicesGrid");
   const filterControls = document.getElementById("filterControls");
   const heroCarousel = document.getElementById("hero-carousel");
+  const modal = document.getElementById("subItemsModal");
+  const modalItems = modal ? modal.querySelector(".modal-items") : null;
+  const modalClose = modal ? modal.querySelector(".modal-close") : null;
+
+  const openModal = items => {
+    if (!modal || !modalItems) return;
+    modalItems.innerHTML = "";
+    items.forEach(item => {
+      const div = document.createElement("div");
+      div.className = "sub-item-card";
+      div.innerHTML = `
+        <img src="${item.img}" alt="${item.name}">
+        <h4>${item.name}</h4>`;
+      modalItems.appendChild(div);
+    });
+    modal.classList.add("open");
+  };
+
+  const closeModal = () => {
+    if (modal) modal.classList.remove("open");
+  };
+
+  if (modalClose) modalClose.addEventListener("click", closeModal);
+  if (modal) {
+    modal.addEventListener("click", e => {
+      if (e.target === modal) closeModal();
+    });
+  }
 
   if (heroCarousel) {
     const slidesContainer = heroCarousel.querySelector(".slides");
@@ -181,31 +209,12 @@ document.addEventListener("DOMContentLoaded", () => {
         <h3>${cat.name}</h3>
         <p>${descriptions[cat.name] || `Explore our ${cat.name.toLowerCase()} solutions.`}</p>
         <button class="details-toggle btn">View Details</button>
-        <ul class="sub-services"></ul>
       `;
-
-      const list = card.querySelector(".sub-services");
-      cat.services.forEach(item => {
-        const li = document.createElement("li");
-        li.className = "sub-card";
-        li.innerHTML = `
-          <a href="products.html#${item.id}">
-            <img src="${item.img}" alt="${item.name}">
-            <span>${item.name}</span>
-          </a>`;
-        list.appendChild(li);
-      });
 
       const toggleBtn = card.querySelector(".details-toggle");
       toggleBtn.addEventListener("click", e => {
         e.preventDefault();
-        const isOpen = list.classList.toggle("open");
-        card.classList.toggle("expanded");
-        if (isOpen) {
-          list.style.maxHeight = list.scrollHeight + "px";
-        } else {
-          list.style.maxHeight = null;
-        }
+        openModal(cat.services);
       });
 
       servicesGrid.appendChild(card);
@@ -221,14 +230,6 @@ document.addEventListener("DOMContentLoaded", () => {
         servicesGrid.querySelectorAll(".service-card").forEach(card => {
           const show = filter === "all" || card.dataset.category === filter;
           card.style.display = show ? "" : "none";
-          if (!show) {
-            const list = card.querySelector(".sub-services");
-            card.classList.remove("expanded");
-            if (list) {
-              list.classList.remove("open");
-              list.style.maxHeight = null;
-            }
-          }
         });
       });
     }

--- a/services.html
+++ b/services.html
@@ -56,6 +56,14 @@
     </div>
   </footer>
 
+  <!-- Modal for sub-items -->
+  <div id="subItemsModal" class="modal" aria-hidden="true">
+    <div class="modal-content">
+      <button class="modal-close" aria-label="Close">&times;</button>
+      <div class="modal-items"></div>
+    </div>
+  </div>
+
   <!-- Scripts -->
   <script src="js/data.js"></script>
   <script src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- add modal structure to `services.html`
- style popup modal in `style.css`
- use JS to open modal with service sub-items instead of expanding cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862733bc0d8832185b0709dfa979ac2